### PR TITLE
設定値の見直し

### DIFF
--- a/src/main/resources/common.properties
+++ b/src/main/resources/common.properties
@@ -2,8 +2,14 @@
 # プロジェクトのベースパッケージ
 nablarch.commonProperty.basePackage=please.change.me.action
 
+# 業務日付のデフォルト区分
+nablarch.businessDateProvider.defaultSegment=01
+
 # トランザクションタイムアウト時間（秒）
 nablarch.transactionFactory.transactionTimeoutSec=60
+
+# データベースへの値自動設定機能で設定する現在日付のデフォルトフォーマット
+nablarch.currentDateTimeAnnotationHandler.dateFormat=yyyyMMdd
 
 # ステートメントのフェッチサイズ
 nablarch.statementFactory.fetchSize=50

--- a/src/main/resources/web-component-configuration.xml
+++ b/src/main/resources/web-component-configuration.xml
@@ -25,7 +25,7 @@
   <import file="nablarch/common/dao.xml" />
 
   <!-- データベース接続設定 -->
-  <import file="nablarch/webui/db-for-webui.xml" />
+  <import file="nablarch/core/db-base.xml" />
   <import file="db.xml"/>
 
   <!-- エラーページ設定 -->


### PR DESCRIPTION
不足していた業務日付のデフォルト区分とデータベースへの値自動設定機能で設定する現在日付のデフォルトフォーマットを追加。
JNDI用のコンポーネント定義は読み込み不要のためimportするコンポーネント定義ファイルを変更。

READMEに記載の方法で動作確認済み。