### PR TITLE
pom.xmlのバージョン記載見直し

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
     <dependency>
       <groupId>com.nablarch.workflow</groupId>
       <artifactId>nablarch-workflow</artifactId>
-      <version>1.1.0</version>
     </dependency>
 
     <dependency>
@@ -159,7 +158,7 @@
       <plugin>
         <groupId>com.nablarch.workflow</groupId>
         <artifactId>nablarch-workflow-tool</artifactId>
-        <version>1.1.0</version>
+        <version>5-NEXT-SNAPSHOT</version>
         <executions>
           <execution>
             <id>generate-csv</id>


### PR DESCRIPTION
## 背景
https://nablarch.atlassian.net/jira/software/c/projects/NAB/issues/NAB-401

## やったこと
- nablarch-workflowのバージョンの記載を取りやめ。
   https://github.com/nablarch/nablarch-profiles/pull/50 でbomにバージョンの記載を移動
- nablarch-workflow-toolのバージョンについて最新のSNAPSHOTに変更

## 確認したこと
- `mvn clean package` 実行時のnablarch-workflow-toolの出力の現新比較。同一であることを確認。
- `mvn waitt:run` でアプリが起動すること。