### PR TITLE
feat: Java17でビルドできるようにライブラリとプラグインのバージョンを更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.18</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     
@@ -293,7 +293,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.2</version>
         <configuration>
           <webXml>${webxml.path}</webXml>
         </configuration>


### PR DESCRIPTION
Java 17 でビルドすると Lombok が Java 17 に対応しておらずエラー

Lombok の Java 17 サポートは、最新の 1.18.22 からなので、バージョンを最新化することで対応。
Java 8, 11 でもエラーにならないことを確認。

https://projectlombok.org/changelog

> v1.18.22 (October 6th, 2021)
> PLATFORM: JDK17 support added. Issue #2898.

このプロジェクトは `maven-war-plugin` に `3.1.0` が指定されていてそのままでも Java 17 でビルドできたが、修正ついでに最新化しておいた。