### PR TITLE
GSPプラグインバージョン更新

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
       <plugin>
         <groupId>jp.co.tis.gsp</groupId>
         <artifactId>gsp-dba-maven-plugin</artifactId>
-        <version>4.7.0</version>
+        <version>4.8.0-SNAPSHOT</version>
         <dependencies>
           <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION
https://github.com/nablarch/nablarch-single-module-archetype/pull/200 の変更を反映するため、gsp-dba-maven-pluginのバージョンを更新しました。

プロジェクトのビルド時に表示されるgsp-dba-maven-pluginのバージョンが更新されていること、アプリケーションを起動してログイン、ワークフローの登録ができるところまで確認しています。